### PR TITLE
BE-1108 update test to remove Windows-only code, update readme & delays

### DIFF
--- a/NMTest.DataSource/DatabaseStore.cs
+++ b/NMTest.DataSource/DatabaseStore.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 
 namespace NMTest.DataSource
 {
     public class DatabaseStore
     {
+        private readonly Dictionary<string, object> _values = new Dictionary<string, object>();
+
         public object GetValue(string key)
         {
-            //simulates 50 ms roundtrip to the database
-            Thread.Sleep(50);
+            //simulates 500 ms roundtrip to the database
+            Thread.Sleep(500);
             object value;
-            if (values.TryGetValue(key, out value))
+            if (_values.TryGetValue(key, out value))
             {
                 return value;
             }
@@ -22,11 +21,9 @@ namespace NMTest.DataSource
 
         public void StoreValue(string key, object value)
         {
-            //simulates 50 ms roundtrip to the database
-            Thread.Sleep(50);
-            values[key] = value;
+            //simulates 500 ms roundtrip to the database
+            Thread.Sleep(500);
+            _values[key] = value;
         }
-
-        Dictionary<string, object> values = new Dictionary<string, object>();
     }
 }

--- a/NMTest.DataSource/DistributedCacheStore.cs
+++ b/NMTest.DataSource/DistributedCacheStore.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 
 namespace NMTest.DataSource
 {
     public class DistributedCacheStore
     {
-        Dictionary<string, object> _Values = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> _values = new Dictionary<string, object>();
         
         public object GetValue(string key)
         {
-            //simulates 5 ms roundtrip to the distributed cache
-            Thread.Sleep(5);
+            //simulates 100 ms roundtrip to the distributed cache
+            Thread.Sleep(100);
             object value;
-            if (_Values.TryGetValue(key, out value))
+            if (_values.TryGetValue(key, out value))
             {
                 return value;
             }
@@ -24,9 +21,9 @@ namespace NMTest.DataSource
 
         public void StoreValue(string key, object value)
         {
-            //simulates 5 ms roundtrip to the distributed cache
-            Thread.Sleep(5);
-            _Values[key] = value;
+            //simulates 100 ms roundtrip to the distributed cache
+            Thread.Sleep(100);
+            _values[key] = value;
         }
     }
 }

--- a/NMTest.DataSource/IDataSource.cs
+++ b/NMTest.DataSource/IDataSource.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace NMTest.DataSource
+﻿namespace NMTest.DataSource
 {
     public interface IDataSource
     {

--- a/NMTest.Sample/Program.cs
+++ b/NMTest.Sample/Program.cs
@@ -6,10 +6,13 @@ namespace NMTest.Sample
     {
         public static void Main(string[] parameters)
         {
+            // your code goes here
+            
             for (var i = 0; i < 10; i++)
             {
                 new Thread(() =>
                 {
+                    // your code goes here   
                 }).Start();
             }
         }

--- a/NMTest.Sample/Program.cs
+++ b/NMTest.Sample/Program.cs
@@ -1,33 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+﻿using System.Threading;
 
 namespace NMTest.Sample
 {
     public static class Program
     {
-
-        [DllImport("winmm.dll")]
-        internal static extern uint timeBeginPeriod(uint period);
-        [DllImport("winmm.dll")]
-        internal static extern uint timeEndPeriod(uint period);
-
         public static void Main(string[] parameters)
         {
-            for (int i = 0; i < 10; i++)
+            for (var i = 0; i < 10; i++)
             {
                 new Thread(() =>
                 {
-                    //Sets the resolution of the timer. This has to be done per thread to ensure that 5ms sleep is actually 5 ms.
-                    //http://stackoverflow.com/a/522681
-                    timeBeginPeriod(5);
-                    //Your code should go here.
-                    timeEndPeriod(5);
-
                 }).Start();
             }
         }

--- a/README.md
+++ b/README.md
@@ -4,24 +4,45 @@ Welcome to the [nearmap.com](nearmap.com) C# test. The purpose of this assignmen
 
 ## Background
 
-The source code that you are given is a very simple imitation of a name/value store. `DatabaseStore` is the canonical data store that takes a while (50 ms) to store and retrieve data. `DistributedCacheStore` is an interface to a distributed cache that takes much less time to turn around - 5 ms. This scenario is a simplified example of a typical high performance server cluster with a database, a distributed cache and multiple worker nodes.
+The source code that you are given is a very simple imitation of a key/value store:
+
+* `DatabaseStore` is the central store that takes a while (500ms) to store and retrieve data.
+* `DistributedCacheStore` is an interface to a distributed cache that takes much less time to turn around (100ms to store or retrieve).
+
+This scenario is a simplified example of a typical high performance server cluster with a database, a distributed cache and multiple worker nodes.
 
 ## Assumptions 
 
-* Data in the canonical store (database) never changes and can be cached forever.
-* Data is never written to the canonical store (database), apart from during the startup.
-* If `GetValue` method returns `null`, the request data item does not exist and will never exist.
-* The solution should start with the distributed cache empty.
-* Provided code can be modified at will.
-* The aim of the test is to produce the simplest working solution to the problem. As such you are at liberty to choose any .NET framework classes.
+After startup:
+
+* Data in `DatabaseStore` never changes and can be cached forever.
+* If `DatabaseStore.GetValue()` returns `null` for a key, the requested data item does not exist and will never exist.
+* `DistributedCacheStore` is initially empty.
 
 ## Task
 
-* The objective is to create a data retrieval mechanism with lowest possible latency by implementing the `IDataSource` interface.
-* The solution should have a better response time than that one of distributed cache for a frequently requested item, i.e. response time should be faster than 5ms.
-* The solution should have unit tests for all new functionality.
+Complete the 2 parts below & submit the solution. 
+If the solution is incomplete, please state what hasn't been finished and outline how you are planning on solving it.
+
+* Provided code can be modified at will.
+* The whole solution must build with no errors.
+* You can use Visual Studio or any other C# IDE.
+
+### Part 1
+
+Implement the `IDataSource` interface to create a mechanism to retrieve data from `DatabaseStore` with lowest possible latency.
+For a frequently-requested item your `IDataSource.GetValue()` implementation should have a better response time than the distributed cache store (ie < 100ms).
+
 * The user of the `IDataStore` interface must not have to deal with thread synchronisation.
-* The database should be populated with the following data on startup:  
+* You must write unit tests for all new functionality, and all tests must pass.
+* You can use any publicly available libraries in unit tests
+* Your non-test code can use an IoC library if desired, and otherwise only .NET Framework or .NET Core libraries/classes
+
+### Part 2
+
+Complete the `Main()` to test your `IDataSource` implementation; it must:
+
+* Populate `DatabaseStore` with the following data at startup:
 <pre>
     | key          | value         |
     --------------------------------
@@ -36,8 +57,8 @@ The source code that you are given is a very simple imitation of a name/value st
     | key8         | value8        |
     | key9         | value9        |
 </pre>
-* The solution must have 10 threads each making 50 consecutive requests for a random key in the range (key0-key9). I.e. there would a total of 500 requests.
-* The solution must print the managed ThreadId, requested key name, returned value, time to complete that request, similar to the following example:  
+* Use 10 threads, each making 50 consecutive requests for a random key in the range (key0-key9). I.e. there would a total of 500 requests.
+* For each request, print the managed ThreadId, requested key name, returned value, time to complete that request; similar to the following example:
 <pre>
     [1] Request 'key1', response 'value1', time: 50.05 ms
     [2] Request 'key2', response 'value2', time: 50.05 ms
@@ -45,6 +66,5 @@ The source code that you are given is a very simple imitation of a name/value st
 
 ## Submission instructions
 
-* The whole Visual Studio solution must build with no errors.
-* If the solution is incomplete, please state what hasn't been finished and outline how you are planning on solving it.
-* DO NOT send pull requests against this repository because we don't want other candidates to see your solution.
+* **DO NOT** fork this repository or create pull requests on it, because we don't want other candidates to see your solution.
+* Provide your solution as a `.zip` or .`gz` archive file, either via email or some Dropbox-like service, to your Nearmap contact.


### PR DESCRIPTION
`winmm.dll` will only work on Windows, not essential to solution.
Change delays because of this - assume 15ms resolution across all
platforms.
Clarify readme.
Conform to our own coding standard.